### PR TITLE
Removing admin_urls loading

### DIFF
--- a/django_logtail/templates/logtail/logtail_list.html
+++ b/django_logtail/templates/logtail/logtail_list.html
@@ -1,6 +1,5 @@
 {% extends "admin/object_history.html" %}
 {% load url from future %}
-{% load admin_urls %}
 
 {% block title %}Logtail {{ block.super }}{% endblock %}
 


### PR DESCRIPTION
django_logtail only works in Django 1.4 due to the admin_urls loading which is a templatetag only present in that Django version.
I think it could be safely removed, doing so, the compatibility at least with Django 1.3 is enabled. This compatibility is more than important since the Django-nonrel for noSQL DBs is 1.3 version, so all of these users won't be able to use django_logtail

I don't know what was the purpose of loading that templatetag but as far as i've tested, after removing it, there is no error and everything works as expected
