### PR TITLE
'url' is not a valid tag library error in django 1.9

### DIFF
--- a/django_logtail/templates/logtail/logtail_list.html
+++ b/django_logtail/templates/logtail/logtail_list.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_list.html" %}
-{% load url from future %}
+
 
 {% block breadcrumbs %}
 <div class="breadcrumbs">


### PR DESCRIPTION
{% load url from future %} yields error “'url' is not a valid tag library”.
There's a post from stackoverflow as well. Pls refer to:
http://stackoverflow.com/questions/5653497/django-load-url-from-future-yields-error-url-is-not-a-valid-tag-libra